### PR TITLE
Changes to use SHA256 sum, SOFTWARE-3006

### DIFF
--- a/lib/OSGCerts.pm
+++ b/lib/OSGCerts.pm
@@ -315,6 +315,10 @@ sub fetch_ca_description {
         $missing_info++;
     }
 
+    if (!defined $description->{tarball_sha256sum}) {
+        log_msg("Description missing: tarball_sha256sum was not specified\n");
+    }
+
     if($missing_info != 0) {
         log_msg("The description file is incomplete.\n");
         $description->{valid} = 0;

--- a/sbin/osg-update-certs
+++ b/sbin/osg-update-certs
@@ -594,6 +594,9 @@ sub dump_description {
             "    Tarball:         '$description->{tarball}'",
             "    Tarball MD5 Sum: '$description->{tarball_md5sum}'",
             "    Timestamp:       '$description->{timestamp}'");
+    if (defined $description->{tarball_sha256sum}) {
+        log_msg("    Tarball SHA256 Sum: '$description->{tarball_sha256sum}'"),
+    }
 }
 
 #---------------------------------------------------------------------
@@ -620,7 +623,22 @@ sub verify_certs_tarball {
     my $description      = $_[0];
     my $tarball_pathname = $_[1];
 
+
+    my $sha256sum = sha256sum($tarball_pathname);
+
+    if (defined $description->{tarball_sha256sum}) {
+        if ($sha256sum eq $description->{tarball_sha256sum}) {
+	    log_msg("Tarball seems uncorrupted: sha256 checksum is $sha256sum\n");
+	    return 1;
+	}
+	else {
+	    log_msg("Tarball appears to be corrupted: sha256 checksum is $sha256sum instead of $description->{tarball_sha256sum}\n");
+	    return 0;
+	}
+    }
+    
     my $md5sum = md5sum($tarball_pathname);
+
     if($md5sum) {
         if ($md5sum eq $description->{tarball_md5sum}) {
             log_msg("Tarball seems uncorrupted: MD5 checksum is $md5sum\n");
@@ -976,6 +994,16 @@ sub md5sum {
     if(OSGCerts::which("md5sum")) {
         my $md5sum_out = `md5sum $file 2> /dev/null`;
         return (split(/ /, $md5sum_out))[0];
+    }
+    return undef;
+}
+
+sub sha256sum{
+    my ($file) = @_;
+
+    if(OSGCerts::which("sha256sum")) {
+        my $sha2sum_out = `sha256sum $file 2> /dev/null`;
+        return (split(/ /, $sha2sum_out))[0];
     }
     return undef;
 }


### PR DESCRIPTION
I tested this with my own url in `/etc/osg/osg-update-certs.conf `. I used this url in replacement

`http://uaf-1.t2.ucsd.edu/~efajardo/ca-certs-version-new`

When the sha256 sum is correct it worked as expected and when changing it to a bad one I got:

```
   2017-12-07T18-36-49 Tarball appears to be corrupted: sha256 checksum is 
   fab947bcf57877f9c92a11703149d32646aa09a844464be4e67e5e7d0858919c instead of 
   fab947bcf57877f9c92a11703149d32646aa09a844464be4e67e5e7d0858919d
   2017-12-07T18-36-49 ERROR: osg-update-certs encountered a fatal error.
   2017-12-07T18-36-49 Message - 'Will not install new certificates because tarball was not good.'
   2017-12-07T18-36-49 Now exiting.
```